### PR TITLE
fix(core): use `mkdirp` package as the folder creation method

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "Tiny boilerplate to work with Vue and Laravel Mix.",
   "main": "index.js",
   "scripts": {
-    "build": "[ -d build\\img ] && mix || mkdir build\\img && mix",
-    "dev": "[ -d build\\img ] && mix watch || mkdir build\\img && mix watch",
+    "create-dev-img-dir": "npx mkdirp build/img",
+    "create-prod-img-dir": "npx mkdirp _dist/assets/img",
+    "build": "npm run create-dev-img-dir && mix",
+    "dev": "npm run create-dev-img-dir && mix watch",
+    "hot": "npm run create-dev-img-dir && mix watch --hot",
     "serve": "npx http-server -p 8000 -a localhost --proxy http://localhost:8000?",
-    "prod": "[ -d _dist\\assets\\img ] && mix --production || mkdir _dist\\assets\\img && mix --production && echo \n\nDeploy the `_dist` folder after compilation"
+    "prod": "npm run create-prod-img-dir && mix --production"
   },
   "author": "Victor Ribeiro",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,11 @@
   "description": "Tiny boilerplate to work with Vue and Laravel Mix.",
   "main": "index.js",
   "scripts": {
-    "create-dev-img-dir": "npx mkdirp build/img",
-    "create-prod-img-dir": "npx mkdirp _dist/assets/img",
-    "build": "npm run create-dev-img-dir && mix",
-    "dev": "npm run create-dev-img-dir && mix watch",
-    "hot": "npm run create-dev-img-dir && mix watch --hot",
+    "build": "npx mkdirp build/img && mix",
+    "dev": "npx mkdirp build/img && mix watch",
+    "hot": "npx mkdirp build/img && mix watch --hot",
     "serve": "npx http-server -p 8000 -a localhost --proxy http://localhost:8000?",
-    "prod": "npm run create-prod-img-dir && mix --production"
+    "prod": "npx mkdirp _dist/assets/img && mix --production"
   },
   "author": "Victor Ribeiro",
   "license": "MIT",


### PR DESCRIPTION
Resolves #34.

In order to fix cross-platform problems I used the [`mkdirp`](https://github.com/isaacs/node-mkdirp) package to create folders in the command line.