### PR TITLE
fix(template): remove default hard-coded dark styles

### DIFF
--- a/.vulmix/components/VulmixWelcome.vue
+++ b/.vulmix/components/VulmixWelcome.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="p-6 space-y-6 bg-zinc-800 text-white h-full">
+    <h1 class="text-5xl">Home</h1>
+
+    <MyComponent />
+
+    <p>And some <Link to="/test-page">Test Page</Link></p>
+    <p>And some <Link to="/non-existing-page">404 page</Link></p>
+  </div>
+</template>
+
+<style scoped lang="scss">
+  // Importing Sass utilities
+  @import '@/assets/sass/utils';
+
+  h1 {
+    color: #d43d3d;
+
+    // Using breakpoint based media-queries
+    @include media(sm) {
+      color: #3b3bcc;
+    }
+
+    @include media(md) {
+      color: #ff0062;
+    }
+
+    @include media(lg) {
+      color: #c78800;
+    }
+
+    @include media(xl) {
+      color: #00a767;
+    }
+
+    @include media('2xl') {
+      color: #c850cc;
+    }
+
+    @include media('3xl') {
+      // Using the `color` function to get a color
+      // from the ./assets/sass/_variables.scss color palette.
+      color: color(sample-gold-400);
+    }
+  }
+
+  a {
+    @apply text-blue-400;
+  }
+</style>

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -2,6 +2,5 @@
 
 html,
 body {
-  background-color: #222;
-  color: #fff;
+  height: 100%;
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,50 +1,5 @@
 <template>
-  <div class="p-6 space-y-6">
-    <h1 class="text-5xl">Home</h1>
-
-    <MyComponent />
-
-    <p>And some <Link to="/test-page">Test Page</Link></p>
-    <p>And some <Link to="/non-existing-page">404 page</Link></p>
+  <div>
+    <VulmixWelcome />
   </div>
 </template>
-
-<style scoped lang="scss">
-  // Importing Sass utilities
-  @import '@/assets/sass/utils';
-
-  h1 {
-    color: #d43d3d;
-
-    // Using breakpoint based media-queries
-    @include media(sm) {
-      color: #3b3bcc;
-    }
-
-    @include media(md) {
-      color: #ff0062;
-    }
-
-    @include media(lg) {
-      color: #c78800;
-    }
-
-    @include media(xl) {
-      color: #00a767;
-    }
-
-    @include media('2xl') {
-      color: #c850cc;
-    }
-
-    @include media('3xl') {
-      // Using the `color` function to get a color
-      // from the ./assets/sass/_variables.scss color palette.
-      color: color(sample-gold-400);
-    }
-  }
-
-  a {
-    @apply text-blue-400;
-  }
-</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,3 @@
 <template>
-  <div>
-    <VulmixWelcome />
-  </div>
+  <VulmixWelcome />
 </template>


### PR DESCRIPTION
Resolves #33.

The hard-coded dark styles overwrites the user styles. Instead, I moved the starter template into a built-in `<VulmixWelcome />` component _with_ the dark styles. This way we keep the `pages/index.vue` as clean as possible and ready to be edited.