### PR TITLE
fix(core): allow file path hashing in `watch` mode

### DIFF
--- a/.vulmix/mix.js
+++ b/.vulmix/mix.js
@@ -29,7 +29,16 @@ class VulmixInit {
         },
       })
 
-      .ejs('index.ejs', '_dist')
+      .ejs(
+        ['index.ejs', '_dist/mix-manifest.json'],
+        '_dist',
+        {},
+        {
+          base: '_dist',
+          partials: ['_dist/mix-manifest.json'],
+          mixVersioning: true,
+        }
+      )
 
       .copy('.vulmix/assets/icons/favicon-16x16.png', '_dist/assets/icons')
 

--- a/.vulmix/mix.js
+++ b/.vulmix/mix.js
@@ -73,7 +73,7 @@ class VulmixInit {
        */
       mix
         .serve(
-          'npx http-server -p 8000 -a localhost _dist -c-1 --gzip --proxy http://localhost:8000?',
+          'npx http-server -p 8000 -a localhost _dist --gzip --proxy http://localhost:8000?',
           {
             verbose: false,
             build: false,

--- a/.vulmix/mix.js
+++ b/.vulmix/mix.js
@@ -47,18 +47,16 @@ class VulmixInit {
 
       .extract()
 
-      .after(stats => {
-        mix.imgs({
-          source: 'assets/img',
-          destination: '_dist/assets/img',
-          webp: true,
-          thumbnailsSizes: [1920, 1200, 900, 600, 300, 50],
-          smallerThumbnailsOnly: true,
-          thumbnailsOnly: true,
-          imageminWebpOptions: {
-            quality: 90,
-          },
-        })
+      .imgs({
+        source: 'assets/img',
+        destination: '_dist/assets/img',
+        webp: true,
+        thumbnailsSizes: [1920, 1200, 900, 600, 300, 50],
+        smallerThumbnailsOnly: true,
+        thumbnailsOnly: true,
+        imageminWebpOptions: {
+          quality: 90,
+        },
       })
 
     /**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "create-img-dir": "mkdirp _dist/assets/img",
-    "remove-dist": "rimraf _dist",
+    "remove-dist": "rimraf _dist/assets/_vulmix _dist/assets/css _dist/assets/js",
     "build": "npm run remove-dist && npm run create-img-dir && mix",
     "dev": "npm run remove-dist && npm run create-img-dir && mix watch",
     "serve": "npx http-server -p 8000 -a localhost _dist --gzip --proxy http://localhost:8000?",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "remove-dist": "rimraf _dist",
     "build": "npm run remove-dist && npm run create-img-dir && mix",
     "dev": "npm run remove-dist && npm run create-img-dir && mix watch",
-    "hot": "npm run remove-dist && npm run create-img-dir && mix watch --hot",
     "serve": "npx http-server -p 8000 -a localhost _dist --gzip --proxy http://localhost:8000?",
     "prod": "npm run remove-dist && npm run create-img-dir && mix --production"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run remove-dist && npm run create-img-dir && mix",
     "dev": "npm run remove-dist && npm run create-img-dir && mix watch",
     "hot": "npm run remove-dist && npm run create-img-dir && mix watch --hot",
-    "serve": "npx http-server -p 8000 -a localhost _dist -c-1 --gzip --proxy http://localhost:8000?",
+    "serve": "npx http-server -p 8000 -a localhost _dist --gzip --proxy http://localhost:8000?",
     "prod": "npm run remove-dist && npm run create-img-dir && mix --production"
   },
   "author": "Victor Ribeiro",


### PR DESCRIPTION
Unfortunately, the [`laravel-mix-ejs`](https://github.com/dsktschy/laravel-mix-ejs/) package do not support native hash generation on `--watch` mode, as seen in this issue I opened: https://github.com/dsktschy/laravel-mix-ejs/issues/6.

@dsktschy kindly gave me a workaround, so I could disable the no-cache rule on the `serve` method.