### PR TITLE
feat(core): support for multiple layouts

### DIFF
--- a/.vulmix/components/Layout.vue
+++ b/.vulmix/components/Layout.vue
@@ -1,0 +1,11 @@
+<template>
+  <component :is="'layout-' + name">
+    <slot />
+  </component>
+</template>
+
+<script setup>
+  defineProps({
+    name: String,
+  })
+</script>

--- a/.vulmix/components/Layout.vue
+++ b/.vulmix/components/Layout.vue
@@ -6,6 +6,9 @@
 
 <script setup>
   defineProps({
-    name: String,
+    name: {
+      type: String,
+      default: 'default',
+    },
   })
 </script>

--- a/.vulmix/components/Layout.vue
+++ b/.vulmix/components/Layout.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="'layout-' + name">
+  <component :is="`layout-${name}`">
     <slot />
   </component>
 </template>

--- a/.vulmix/main.js
+++ b/.vulmix/main.js
@@ -95,6 +95,25 @@ const router = createRouter({
 /**
  * Layouts
  */
+const nativeLayoutFiles = require.context('@/layouts/', true, /\.(vue|js)$/i)
+nativeLayoutFiles
+  .keys()
+  .map(key => {
+    const nativeLayoutName =
+      'layout-' +
+      key
+        .split('.')[1]
+        .replace(/\//g, '')
+        .replace(/([A-Z])/g, '-$1')
+        .replace(/(^-)/g, '')
+        .toLowerCase()
+
+    app.component(nativeLayoutName, nativeLayoutFiles(key).default)
+  })
+
+/**
+ * Layouts
+ */
 const layoutFiles = require.context('@layouts/', true, /\.(vue|js)$/i)
 layoutFiles
   .keys()

--- a/.vulmix/main.js
+++ b/.vulmix/main.js
@@ -91,6 +91,26 @@ const router = createRouter({
   routes: routes,
 })
 
+
+/**
+ * Layouts
+ */
+const layoutFiles = require.context('@layouts/', true, /\.(vue|js)$/i)
+layoutFiles
+  .keys()
+  .map(key => {
+    const layoutName =
+      'layout-' +
+      key
+        .split('.')[1]
+        .replace(/\//g, '')
+        .replace(/([A-Z])/g, '-$1')
+        .replace(/(^-)/g, '')
+        .toLowerCase()
+
+    app.component(layoutName, layoutFiles(key).default)
+  })
+
 app.use(router)
 app.use(head)
 

--- a/.vulmix/main.js
+++ b/.vulmix/main.js
@@ -95,26 +95,8 @@ const router = createRouter({
 /**
  * Layouts
  */
-const nativeLayoutFiles = require.context('@/layouts/', true, /\.(vue|js)$/i)
-nativeLayoutFiles
-  .keys()
-  .map(key => {
-    const nativeLayoutName =
-      'layout-' +
-      key
-        .split('.')[1]
-        .replace(/\//g, '')
-        .replace(/([A-Z])/g, '-$1')
-        .replace(/(^-)/g, '')
-        .toLowerCase()
-
-    app.component(nativeLayoutName, nativeLayoutFiles(key).default)
-  })
-
-/**
- * Layouts
- */
 const layoutFiles = require.context('@layouts/', true, /\.(vue|js)$/i)
+
 layoutFiles
   .keys()
   .map(key => {

--- a/.vulmix/mix.js
+++ b/.vulmix/mix.js
@@ -23,6 +23,7 @@ class VulmixInit {
             '@assets': path.resolve(__dirname, '../assets'),
             '@components': path.resolve(__dirname, '../components'),
             '@composables': path.resolve(__dirname, '../composables'),
+            '@layouts': path.resolve(__dirname, '../layouts'),
             '@pages': path.resolve(__dirname, '../pages'),
             '@sass': path.resolve(__dirname, '../assets/sass'),
           },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,5 @@
+<template>
+  <!-- Put your layout around the slot tag -->
+  <slot />
+  <!-- Put your layout around the slot tag -->
+</template>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,13 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './index.html',
-    './.vulmix/**/pages/*.{vue,html,js}',
-    './.vulmix/**/components/*.{vue,html,js}',
-    './pages/*.{vue,html,js}',
-    './components/*.{vue,html,js}',
+    './app.vue',
+    './.vulmix/**/pages/*.{vue,js}',
+    './.vulmix/**/components/*.{vue,js}',
+    './.vulmix/**/layouts/*.{vue,js}',
+    './pages/*.{vue,js}',
+    './components/*.{vue,js}',
+    './layouts/*.{vue,js}',
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
Resolves #30.

This PR adds support for multiple layouts by simply creating a Vue file inside the `layouts` folder.

## Creating a layout

Let's say that you want to create a layout for the "about" page. Simply create an `about.vue` file inside the `layouts` folder:

![image](https://user-images.githubusercontent.com/8026741/193365247-ee9b9a17-a591-46f7-b0e6-954acc837f6e.png)

> You can use `kebab-case` or `PascalCase` in the layout name.

Inside `layouts/about.vue`, create your HTML layout around a `<slot />` tag:

```vue
<!-- layouts/about.vue -->

<template>
  <!-- Put your layout around the slot -->
  <slot />
  <!-- Put your layout around the slot -->
</template>
```

## Using the `<Layout>` component

In the `pages/about.vue`, wrap the content inside a `<Layout>` component, passing the layout name as a prop:

```vue
<!-- pages/about.vue -->

<template>
  <Layout name="about">
    That's my About page
  </Layout>
</template>
```

Your page will inherit all the `layouts/about.vue` components and styles.

> ℹ️ **Tip:** If you use the `<Layout>` component in the root `app.vue` file, the layout will be applied to every page.