### PR TITLE
feat(core): dynamic routes

### DIFF
--- a/.vulmix/main.js
+++ b/.vulmix/main.js
@@ -81,6 +81,31 @@ pageComponents
     })
   })
 
+/**
+ * Dynamic Pages
+ */
+const dynamicPageComponents = require.context('@pages/', true, /\[(.*)\]\.(vue|js)$/i)
+dynamicPageComponents
+  .keys()
+  .map(key => {
+    let slugName = key
+      .split('.')[1]
+      .replace(/([A-Z])/g, '-$1')
+      .replace(/(^-)/g, '')
+      .toLowerCase()
+
+    if (slugName.match(/\/index$/)) {
+      slugName = slugName.replace('/index', '/')
+    } else {
+      slugName = slugName.replace(/\/\[(.*)\]/, '/:$1')
+    }
+
+    routes.push({
+      path: slugName === '/index' ? '/' : `/${slugName}`,
+      component: dynamicPageComponents(key).default,
+    })
+  })
+
 routes.push({
   path: '/:pathMatch(.*)*',
   component: require('@/pages/404.vue').default,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "autoprefixer": "^10.4.8",
     "browser-sync": "^2.27.10",
     "browser-sync-webpack-plugin": "^2.3.0",
-    "imagemin-jpegtran": "^7.0.0",
     "laravel-mix": "^6.0.49",
     "laravel-mix-ejs": "^2.0.0",
     "laravel-mix-replace-in-file": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@vue/compiler-sfc": "^3.2.37",
     "@vueuse/core": "^9.2.0",
     "@vueuse/head": "^0.7.12",
+    "@vueuse/router": "^9.3.0",
     "autoprefixer": "^10.4.8",
     "browser-sync": "^2.27.10",
     "browser-sync-webpack-plugin": "^2.3.0",


### PR DESCRIPTION
Resolves #49.

With dynamic routes, you can create a route wrapping the page file name in brackets:

![image](https://user-images.githubusercontent.com/8026741/193370390-e1b4e822-c66f-4384-9e5a-5a589b7eadec.png)

Then you can access any route and get the url parameter with the [@vueuse/router `useRouteParams`](https://vueuse.org/router/userouteparams/) composable:

```vue
<!-- pages/[id].vue -->

<template>
  {{ userId }}
</template>

<script setup>
  import { useRouteParams } from '@vueuse/router'

  const userId = useRouteParams('id')
</script>
```

Will generate:

![image](https://user-images.githubusercontent.com/8026741/193370548-df0f82af-e6c7-455d-ba35-daab10da038d.png)

Then, you can use the generated `userId` within an API call.