### PR TITLE
feat(core/components): support for Iconify icons

### DIFF
--- a/demo/app.vue
+++ b/demo/app.vue
@@ -1,3 +1,6 @@
 <template>
-  <VulmixWelcome />
+  <div style="font-size: 3rem; display: flex;">
+    <Icon name="vulmix" />
+    <Icon icon="carbon:ai-results-very-high" />
+  </div>
 </template>

--- a/demo/app.vue
+++ b/demo/app.vue
@@ -1,6 +1,3 @@
 <template>
-  <div style="font-size: 3rem; display: flex;">
-    <Icon name="vulmix" />
-    <Icon icon="carbon:ai-results-very-high" />
-  </div>
+  <VulmixWelcome />
 </template>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "devDependencies": {},
   "dependencies": {
+    "@iconify/vue": "^4.0.2",
     "@vue/compiler-sfc": "^3.2.37",
     "@vueuse/core": "^9.2.0",
     "@vueuse/head": "^1.0.16",

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -10,7 +10,11 @@
     "
   ></i>
 
-  <Icon v-else :icon="props.icon" />
+  <component
+    v-else
+    :is="props.icon && Icon"
+    :icon="props.icon"
+  ></component>
 </template>
 
 <style scoped lang="scss">

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -20,7 +20,7 @@
   ></component>
 </template>
 
-<style scoped lang="scss">
+<style scoped>
   .icon {
     display: inline-block;
     vertical-align: middle;

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -1,5 +1,7 @@
 <template>
-  <i v-if="!props.icon"
+  <i
+    v-if="!props.icon"
+    class="icon"
     :style="
       props.font === 'true'
         ? {
@@ -14,21 +16,25 @@
     v-else
     :is="props.icon && Icon"
     :icon="props.icon"
+    class="icon"
   ></component>
 </template>
 
 <style scoped lang="scss">
-  i {
+  .icon {
     display: inline-block;
     vertical-align: middle;
+    width: 1em;
+    height: 1em;
+  }
+
+  i.icon {
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
     mask-size: contain;
     mask-repeat: no-repeat;
     mask-position: center;
-    width: 1em;
-    height: 1em;
   }
 </style>
 

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -1,5 +1,5 @@
 <template>
-  <i
+  <i v-if="!props.icon"
     :style="
       props.font === 'true'
         ? {
@@ -8,7 +8,9 @@
           }
         : { 'background-image': `url(${maskSrc})` }
     "
-  />
+  ></i>
+
+  <Icon v-else :icon="props.icon" />
 </template>
 
 <style scoped lang="scss">
@@ -28,9 +30,13 @@
 
 <script setup>
   import { computed } from 'vue'
+  import { Icon } from '@iconify/vue'
 
   const props = defineProps({
     name: {
+      type: String,
+    },
+    icon: {
       type: String,
     },
     font: {


### PR DESCRIPTION
Resolves #87.

The original idea is to use the `name` prop to use custom icons on the `assets/icons` folder and the `icon` prop for the [Iconify icons](https://icon-sets.iconify.design/).

eg.:

```vue
<!-- Vulmix custom icons -->
<Icon name="my-icon" />

<!-- Iconify icons -->
<Icon icon="ic:baseline-accessibility-new" />
```