### PR TITLE
refactor: remove auto-imports for VueUse

### DIFF
--- a/src/config/imports.js
+++ b/src/config/imports.js
@@ -51,7 +51,6 @@ module.exports.UnpluginAutoImports = () => {
         ...(VulmixConfig.imports?.presets || []),
         'vue',
         'vue-router',
-        '@vueuse/core',
         'pinia',
       ],
       // Enable auto import by filename for default module exports under directories


### PR DESCRIPTION
I think it's better for the users to decide if they want to include VueUse on the imports option on vulmix.config.ts