### PR TITLE
`0.6.2-beta`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vulmix",
-  "version": "0.6.1-beta",
+  "version": "0.6.2-beta",
   "description": "Vue(3) meta-framework that uses Laravel Mix.",
   "repository": "ojvribeiro/vulmix",
   "main": "./src/mix.js",


### PR DESCRIPTION
> This is the last patch release for the `0.6.x-beta` version before `0.7.0`.

## Checklist

- [x] I changed the Vulmix version on the package.json file.
- [x] I changed the Vulmix version on [ojvribeiro/vulmix-starter-template](https://github.com/ojvribeiro/vulmix-starter-template).
- [x] I updated the docs accordingly on [ojvribeiro/vulmix-docs](https://github.com/ojvribeiro/vulmix-docs).

## 🐞 Bug fixes

- core: fixed aliases for images (#202)
- components: added official docs URL to `<VulmixWelcome>` (#203)
- fixes regression in props autocompletion (#205)

## 📦 Dependencies

- deps: bump `@types/node` to `20.4.4` (#208)
- deps: bump `postcss` to `8.4.27` (#207)
- deps: bump `sass` to `1.64.1` (#209)